### PR TITLE
Add optional author credits to quote output

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -94,7 +94,7 @@ if (arg === '-b' || arg === '--brainyquote') {
 	showMessage();
 	got(url).then(res => {
 		const $ = cheerio.load(res.body);
-		const author = $('.bq-aut:link').eq(0).text();
+		const author = $('.bq-aut:link').eq(0).text().trim();
 		const quote = $('.b-qt:link').eq(0).text().trim();
 		showQuotes(`"${quote}"`, `${author}`);
 	}).catch(err => {

--- a/cli.js
+++ b/cli.js
@@ -17,6 +17,7 @@ updateNotifier({pkg}).notify();
 const spinner = ora();
 
 const arg = process.argv[2];
+const optionalArg = process.argv[3];
 const quotePre = `${chalk.bold.cyan('›')} `;
 const authorPre = `${chalk.bold.cyan('\t--')} `;
 
@@ -31,16 +32,12 @@ const showError = () => {
 	process.exit(1);
 };
 
-const showQuotes = arg => {
+const showQuotes = (arg, optional) => {
 	logUpdate();
 	console.log(`${quotePre}${arg}`);
-	console.log();
-	spinner.stop();
-};
-
-const showAuthor = arg => {
-	logUpdate();
-	console.log(`${authorPre}${arg}`);
+	if (optionalArg) {
+		console.log(`${authorPre}${optional}`);
+	}
 	console.log();
 	spinner.stop();
 };
@@ -58,15 +55,18 @@ const dnsBrainy = () => {
 	});
 };
 
-const args = ['-b', '--brainyquote', '-e', '--eduro', '-l', '--love', '-a', '--art', '-n', '--nature', '-f', '--funny', '-v', '--version', '-s', '--source'];
+const args = ['-b', '--brainyquote', '-e', '--eduro', '-l', '--love', '-a', '--art', '-n', '--nature', '-f', '--funny', '-v', '--version', '-s', '--source', '-u', '--author'];
 
 if (!arg || arg === '-h' || arg === '--help' || args.indexOf(arg) === -1) {
 	console.log(`
- ${chalk.cyan('Usage:')} kote <command>
+ ${chalk.cyan('Usage:')} kote <command> <option>
 
  ${chalk.cyan('Command: ')}
   -b, --brainyquote      ${quoteOftheDay()} : BrainyQuotes
   -e, --eduro            ${quoteOftheDay()} : Eduro
+
+ ${chalk.cyan('Options: ')}
+  -u, --author           ${quoteOftheDay()} : Show Author
 
  ${chalk.cyan('Extra :')}
   -l, --love             ${quoteOftheDay()} : Love
@@ -96,8 +96,7 @@ if (arg === '-b' || arg === '--brainyquote') {
 		const $ = cheerio.load(res.body);
 		const author = $('.bq-aut:link').eq(0).text();
 		const quote = $('.b-qt:link').eq(0).text().trim();
-		showQuotes(`"${quote}"`);
-		showAuthor(`${author}`);
+		showQuotes(`"${quote}"`, `${author}`);
 	}).catch(err => {
 		if (err) {
 			showError();

--- a/cli.js
+++ b/cli.js
@@ -17,7 +17,8 @@ updateNotifier({pkg}).notify();
 const spinner = ora();
 
 const arg = process.argv[2];
-const pre = `${chalk.bold.cyan('›')} `;
+const quotePre = `${chalk.bold.cyan('›')} `;
+const authorPre = `${chalk.bold.cyan('\t--')} `;
 
 const showMessage = () => {
 	logUpdate();
@@ -26,13 +27,20 @@ const showMessage = () => {
 };
 
 const showError = () => {
-	logUpdate(`\n${pre} ${chalk.dim('Could not find the Quote. Please try again!')}\n`);
+	logUpdate(`\n${quotePre} ${chalk.dim('Could not find the Quote. Please try again!')}\n`);
 	process.exit(1);
 };
 
 const showQuotes = arg => {
 	logUpdate();
-	console.log(`${pre}${arg}`);
+	console.log(`${quotePre}${arg}`);
+	console.log();
+	spinner.stop();
+};
+
+const showAuthor = arg => {
+	logUpdate();
+	console.log(`${authorPre}${arg}`);
 	console.log();
 	spinner.stop();
 };
@@ -86,8 +94,10 @@ if (arg === '-b' || arg === '--brainyquote') {
 	showMessage();
 	got(url).then(res => {
 		const $ = cheerio.load(res.body);
+		const author = $('.bq-aut:link').eq(0).text();
 		const quote = $('.b-qt:link').eq(0).text().trim();
 		showQuotes(`"${quote}"`);
+		showAuthor(`${author}`);
 	}).catch(err => {
 		if (err) {
 			showError();
@@ -184,5 +194,5 @@ if (arg === '-f' || arg === '--funny') {
 }
 
 if (arg === '--version' || arg === '-v') {
-	console.log(`\n${pre}Current kote version:`, require('./package.json').version, `\n`);
+	console.log(`\n${quotePre}Current kote version:`, require('./package.json').version, `\n`);
 }

--- a/cli.js
+++ b/cli.js
@@ -35,7 +35,7 @@ const showError = () => {
 const showQuotes = (arg, optional) => {
 	logUpdate();
 	console.log(`${quotePre}${arg}`);
-	if (optionalArg) {
+	if (optionalArg === '-u' || optionalArg === '--author') {
 		console.log(`${authorPre}${optional}`);
 	}
 	console.log();

--- a/cli.js
+++ b/cli.js
@@ -115,8 +115,9 @@ if (arg === '-e' || arg === '--eduro') {
 	showMessage();
 	got(url).then(res => {
 		const $ = cheerio.load(res.body);
+		const author = $('.article dailyquote p.author').eq(0).text().trim().substring(2);
 		const quote = $('.article dailyquote p').eq(0).text().trim();
-		showQuotes(`"${quote}"`);
+		showQuotes(`"${quote}"`, `${author}`);
 	}).catch(err => {
 		if (err) {
 			showError();

--- a/test.js
+++ b/test.js
@@ -22,3 +22,25 @@ test.cb('brainyquote', t => {
 		t.end();
 	});
 });
+
+test.cb('eduro with author', t => {
+	const cp = childProcess.spawn('./cli.js', ['-e', '-u'], {stdio: 'inherit'});
+
+	cp.on('error', t.ifError);
+
+	cp.on('close', code => {
+		t.is(code, 0);
+		t.end();
+	});
+});
+
+test.cb('brainyquote with author', t => {
+	const cp = childProcess.spawn('./cli.js', ['-b', '-u'], {stdio: 'inherit'});
+
+	cp.on('error', t.ifError);
+
+	cp.on('close', code => {
+		t.is(code, 0);
+		t.end();
+	});
+});


### PR DESCRIPTION
Hello!

Just wanted to say I love your package. It's simple and looks clean, and I've been using it for a long time now. Something I've always wanted from this that my own quote script used to have is author credit. Lots of times I see some really nice quotes, but have no idea who said them. Plus, its a little sad that the application is sharing quotes but not giving any credit to the person who says/said them!

This PR adds a command line option for turning on author credit output. The use of `--author` or `-u` (`-a` was taken by `--art`) enables `kote` to output the author of the quote. Here is an example of such an output:

```
$ ./cli.js -b -u

› "Everyone is a genius at least once a year. The real geniuses simply have their bright ideas closer together."
        -- Georg C. Lichtenberg
```

I tried to keep the output simple so that the aesthetic is still there. You are of course free to suggest alternatives, such as changing the '--' to a different character(s). I also tried to stay within the scope of your code-style. For example, I avoided line-wrapping to 80 columns since it seems like you do not adhere to that.